### PR TITLE
Add basic SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Each endpoint should be configured with the following variables:
 
   * `name`: endpoint identifier string
   * `domains`: list of domains to be served
-  * `lb_method`: optional load balancing method (hash, ip_hash, least_conn or least_time - see [upstream module documentation](http://nginx.org/en/docs/http/ngx_http_upstream_module.html))
+  * `lb_method`: optional load balancing method (hash, ip_hash, or least_conn - see [upstream module documentation](http://nginx.org/en/docs/http/ngx_http_upstream_module.html))
   * `backends`: list of backend servers (see accepted [format](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#server))
 
 Example Playbook
@@ -36,5 +36,5 @@ Example Playbook
           backends:
             - localhost:8080 weight=2
             - localhost:8081
-          lb_method: least_time
+          lb_method: least_conn
 ```    

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Each endpoint should be configured with the following variables:
   * `domains`: list of domains to be served
   * `lb_method`: optional load balancing method (hash, ip_hash, or least_conn - see [upstream module documentation](http://nginx.org/en/docs/http/ngx_http_upstream_module.html))
   * `backends`: list of backend servers (see accepted [format](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#server))
+  * SSL can optionally be configured:
+    * `ssl_enabled`: set to `true` to enable SSL. These variables must also be specified if SSL is enabled:
+      * `ssl_certificate`: path to SSL certificate
+      * `ssl_certificate_key`: path to SSL certificate key
+
 
 Example Playbook
 ----------------
@@ -37,4 +42,14 @@ Example Playbook
             - localhost:8080 weight=2
             - localhost:8081
           lb_method: least_conn
+        - name: example-ssl-app
+          domains:
+            - example-ssl.net
+          backends:
+            - localhost:8083
+            - localhost:8084
+          ssl_enabled: true
+          ssl_certificate: /etc/nginx/ssl/example-ssl.net.crt
+          ssl_certificate_key: /etc/nginx/ssl/example-ssl.net.key
+
 ```    

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 
 nginx_reverse_port: 80
+nginx_reverse_ssl_port: 443

--- a/templates/endpoint.conf.j2
+++ b/templates/endpoint.conf.j2
@@ -2,7 +2,7 @@
 
 upstream {{ item.name }} {
     {% if item.lb_method is defined %}
-    {{ item.lb_method }}
+    {{ item.lb_method }};
     {% endif %}
     {% for backend in item.backends %}
     server {{ backend }};
@@ -11,6 +11,11 @@ upstream {{ item.name }} {
 
 server {
     listen {{ nginx_reverse_port }};
+    {% if item.ssl_enabled |default(false) %}
+    listen {{ nginx_reverse_ssl_port}} ssl;
+    ssl_certificate {{ item.ssl_certificate }};
+    ssl_certificate_key {{ item.ssl_certificate_key }};
+    {% endif %}
     server_name {{ item.domains|join(' ') }};
     location / {
         proxy_set_header   X-Real-IP $remote_addr;


### PR DESCRIPTION
This assumes that the server should be deployed to support both protocols rather than HTTPS-only, which should probably be revisited. Tested in local VMs with self-signed certificates.

@gtirloni, if you have a chance to review quickly - I'm assuming we'll want to store the SSL certs in the /etc/nginx/ssl directory that gets created by the nginx-common role.