### PR TITLE
Added the X-Forwarded-For option to the proxypass

### DIFF
--- a/templates/endpoint.conf.j2
+++ b/templates/endpoint.conf.j2
@@ -31,8 +31,9 @@ server {
     server_name {{ item.domains|join(' ') }};
 
     location / {
-        proxy_set_header   X-Real-IP $remote_addr;
-        proxy_set_header   Host      $http_host;
+        proxy_set_header   X-Real-IP       $remote_addr;
+        proxy_set_header   Host            $http_host;
+        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_pass         {{ item.backend_protocol | default('http') }}://{{ item.name }};
     }
 }


### PR DESCRIPTION
The [X-Forwareded-For header](https://en.wikipedia.org/wiki/X-Forwarded-For) is very useful to know the real IP of a client, and to identify the proxys that are between the client and the backend server. Mediawiki [uses this header](https://www.mediawiki.org/wiki/Manual:$wgUsePrivateIPs)  to identify the IP of the client, for example.

