### PR TITLE
Proposal: `directives`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Each endpoint should be configured with the following variables:
     * `ssl_enabled`: set to `true` to enable SSL. These variables must also be specified if SSL is enabled:
       * `ssl_certificate`: path to SSL certificate
       * `ssl_certificate_key`: path to SSL certificate key
-
+  * Additional directives can be added under `directives`. Be careful.
 
 Example Playbook
 ----------------
@@ -48,6 +48,9 @@ Example Playbook
           backends:
             - localhost:8083
             - localhost:8084
+          directives:
+            - 'client_max_body_size 128m'
+            - 'client_header_timeout 60s'
           ssl_enabled: true
           ssl_certificate: /etc/nginx/ssl/example-ssl.net.crt
           ssl_certificate_key: /etc/nginx/ssl/example-ssl.net.key

--- a/templates/endpoint.conf.j2
+++ b/templates/endpoint.conf.j2
@@ -28,6 +28,12 @@ server {
     ssl_certificate_key {{ item.ssl_certificate_key }};
     {% endif %}
 
+    {% if item.directives is defined %}
+    {%- for entry in item.directives -%}
+    {{- entry }};
+    {% endfor %}
+    {% endif %}
+
     server_name {{ item.domains|join(' ') }};
 
     location / {


### PR DESCRIPTION
I would like to propose we allow users to specify ad-hoc directives that are not covered by the role. This should allow for all sorts of customizations.

If in the future we identify categories of customizations that are common used, maybe then it'll make sense to add a `type` variable that allow one to specify that and avoid polluting the YAML files with lots of customizations.

Please share your thoughts.