### PR TITLE
Added max_body_size option

### DIFF
--- a/templates/endpoint.conf.j2
+++ b/templates/endpoint.conf.j2
@@ -40,6 +40,10 @@ server {
         {% if nginx_reverse_enable_rate_limiting %}
         limit_req zone=perip burst={{ nginx_reverse_rate_limiting_requests_burst_size }};
         {% endif %}
+
+        {% if item.max_body_size %}
+        client_max_body_size {{ item.max_body_size }};
+        {% endif %}
         
         proxy_set_header   X-Real-IP       $remote_addr;
         proxy_set_header   Host            $http_host;


### PR DESCRIPTION
This PR adds the hability to set the [client max body size option](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) in each nginx reverse item. This is needed by some applications like Jira or Mediawiki.