### PR TITLE
Remove ansible_managed directive

### DIFF
--- a/templates/endpoint.conf.j2
+++ b/templates/endpoint.conf.j2
@@ -1,5 +1,3 @@
-# {{ ansible_managed }}
-
 upstream {{ item.name }} {
     {% if item.lb_method is defined %}
     {{ item.lb_method }};


### PR DESCRIPTION
This causes files to be reported as changed when the only change is in the ansible_managed header itself (makes it hard to track changes by inspecting the playbook output).